### PR TITLE
Fix Circle collision detection

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -262,11 +262,11 @@ window.addEventListener("load", function () {
 
   function colCheck(shapeA, shapeB) {
     // get the vectors to check against
-    var vX = (shapeA.x + (shapeA.width / 2)) - (shapeB.x + (shapeB.width / 2)),
-      vY = (shapeA.y + (shapeA.height / 2)) - (shapeB.y + (shapeB.height / 2)),
+    var vX = shapeA.x - (shapeB.x + (shapeB.width / 2)),
+      vY = shapeA.y - (shapeB.y + (shapeB.height / 2)),
       // add the half widths and half heights of the objects
-      hWidths = (shapeA.width / 2) + (shapeB.width / 2),
-      hHeights = (shapeA.height / 2) + (shapeB.height / 2),
+      hWidths = shapeA.width + (shapeB.width / 2),
+      hHeights = shapeA.height + (shapeB.height / 2),
       colDir = null;
 
     // if the x and y vector are less than the half width or half height, they we must be inside the object, causing a collision


### PR DESCRIPTION
As `shapeA` is a circle we don't need to sum his half width/height